### PR TITLE
Front-00 - Feat: Criar componente para tratamento de exceções

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
+        "react-toastify": "^10.0.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -15624,6 +15625,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,26 @@
-import { BrowserRouter as Router,Routes,Route,Link } from 'react-router-dom';
-import * as React from 'react';
-import Dashboard from './pages/Dashboard'
-import Eventos from './pages/Eventos'
-import Metricas from './pages/Metricas';
-import Navbar from './components/Navbar';
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import * as React from "react";
+import Dashboard from "./pages/Dashboard";
+import Eventos from "./pages/Eventos";
+import Metricas from "./pages/Metricas";
+import Navbar from "./components/Navbar";
+import "react-toastify/dist/ReactToastify.css";
+import { ToastContainer } from "react-toastify";
+
 
 function App() {
   return (
     <>
-      <Navbar/>
+      <Navbar />
+      <ToastContainer />;
       <Router>
         <Routes>
-          <Route path='/' element={<Dashboard/>} />
-          <Route path='/eventos' element={<Eventos/>} />
-          <Route path='/metricas' element={<Metricas/>} />
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/eventos" element={<Eventos />} />
+          <Route path="/metricas" element={<Metricas />} />
         </Routes>
       </Router>
     </>
-      
   );
 }
 

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,32 +1,47 @@
-import Button from '@mui/material/Button';
-import DemoPaper from '@mui/material/Paper'
-import Event from '@mui/icons-material/Event';
-import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
+import Button from "@mui/material/Button";
+import DemoPaper from "@mui/material/Paper";
+import Event from "@mui/icons-material/Event";
+import FormatListNumberedIcon from "@mui/icons-material/FormatListNumbered";
+import { toast } from "react-toastify";
+import ErrorService from "../services/errorService";
 
-function Dashboard(){
-    return(
-        <>
-        <a href="/eventos">
-            <Button>
-                <DemoPaper square={false}>
-                    <Event/>
-                    <p>Eventos</p>
-                </DemoPaper>
-            </Button>
-        </a>
+function Dashboard() {
+    
+  const handleSomeAction = async () => {
+    const error = {
+      response: {
+        status: 500,
+        data: {
+          message: "Erro interno do servidor",
+        },
+      },
+    };
+    ErrorService.handleError(error);
+  };
 
-        <a href="/metricas">
-            <Button>
-                <DemoPaper square={false}>
-                    <FormatListNumberedIcon/>
-                    <p>Métricas</p>
-                </DemoPaper>
-            </Button>
-        </a>
+  return (
+    <>
+      <a href="/eventos">
+        <Button>
+          <DemoPaper square={false}>
+            <Event />
+            <p>Eventos</p>
+          </DemoPaper>
+        </Button>
+      </a>
 
-        
-        </>
-    )
+      <a href="/metricas">
+        <Button>
+          <DemoPaper square={false}>
+            <FormatListNumberedIcon />
+            <p>Métricas</p>
+          </DemoPaper>
+        </Button>
+      </a>
+
+      <button onClick={handleSomeAction}>Clique para acionar erro</button>
+    </>
+  );
 }
 
-export default Dashboard
+export default Dashboard;

--- a/src/services/errorService.js
+++ b/src/services/errorService.js
@@ -1,0 +1,26 @@
+import { toast } from "react-toastify";
+
+const ErrorService = {
+  handleError: (error) => {
+    // Aqui você pode adicionar lógica para tratar diferentes tipos de erros
+    // e exibir mensagens apropriadas.
+    if (error.response) {
+      // Erros de resposta do servidor (código de status fora da faixa 2xx)
+      toast.error(
+        `Erro: ${error.response.status} - ${
+          error.response.data.message || "Erro no servidor"
+        }`
+      );
+    } else if (error.request) {
+      // Erros que ocorreram ao fazer a requisição
+      toast.error(
+        "Erro: Falha ao se comunicar com o servidor. Verifique sua conexão."
+      );
+    } else {
+      // Outros erros
+      toast.error(`Erro: ${error.message}`);
+    }
+  },
+};
+
+export default ErrorService;


### PR DESCRIPTION
Foi implementado um serviço para tratamento de erro.
Um exemplo de uso foi deixado na tela inicial.

Basta passar qualquer objeto de erro para ele, que ele irá logar, sendo possível adicionar mais tratamentos.

Foi utilizado a biblioteca react-toastify, logo, além do serviço para tratar erros, é possível a biblioteca para as notificaçõe de sucesso.